### PR TITLE
chore(ci): re-pin org workflows to Actions v0.8.1 + dependabot auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    labels:
+      - "dep/github-actions"
   - package-ecosystem: "terraform"
     directory: "/"
     schedule:
@@ -17,6 +19,8 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    labels:
+      - "dep/terraform-module"
   - package-ecosystem: "terraform"
     directory: "/modules/kv_certificates"
     schedule:
@@ -24,6 +28,8 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    labels:
+      - "dep/terraform-module"
   - package-ecosystem: "terraform"
     directory: "/modules/kv_certificates/example"
     schedule:
@@ -31,6 +37,8 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    labels:
+      - "dep/terraform-module"
   - package-ecosystem: "terraform"
     directory: "/modules/kv_key"
     schedule:
@@ -38,3 +46,5 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    labels:
+      - "dep/terraform-module"

--- a/.github/workflows/org-dependabot-auto-merge.yml
+++ b/.github/workflows/org-dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot Auto-Merge
+
+# Evaluates Dependabot PRs for auto-merge eligibility using the org reusable
+# workflow: supply-chain checks (OSV + OpenSSF Scorecard), breaking-change
+# detection (semver + AI changelog analysis), then approves + auto-merges or
+# labels for manual review. Installed fleet-wide by the v0.8 unified wave.
+#
+# Uses pull_request_target (not pull_request) so the workflow has write
+# permissions on Dependabot PRs. The reusable workflow only reads metadata
+# from the PR branch, never executes code from it.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot-auto-merge.yml@3ce5211dee2e8758e2e992b13371e3e85517cfbd # v0.8.1
+    secrets: inherit

--- a/.github/workflows/org-dependabot.yml
+++ b/.github/workflows/org-dependabot.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   refresh:
-    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot.yml@v0.5.1
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot.yml@3ce5211dee2e8758e2e992b13371e3e85517cfbd # v0.8.1
     with:
       head_branch: ${{ github.head_ref || github.ref_name }}  # PR head, or current branch if not a PR
       include_github_actions: "true"

--- a/.github/workflows/org-md-lint.yml
+++ b/.github/workflows/org-md-lint.yml
@@ -14,4 +14,4 @@ on:
 
 jobs:
   check-markdown:
-    uses: Coalfire-CF/Actions/.github/workflows/org-markdown-lint.yml@v0.6.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-markdown-lint.yml@3ce5211dee2e8758e2e992b13371e3e85517cfbd # v0.8.1

--- a/.github/workflows/org-release.yml
+++ b/.github/workflows/org-release.yml
@@ -15,5 +15,5 @@ on:
 
 jobs:
   create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@v0.5.1
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@3ce5211dee2e8758e2e992b13371e3e85517cfbd # v0.8.1
     secrets: inherit

--- a/.github/workflows/org-terraform-docs.yml
+++ b/.github/workflows/org-terraform-docs.yml
@@ -16,4 +16,4 @@ on:
 
 jobs:
   terraform-docs:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@v0.6.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@3ce5211dee2e8758e2e992b13371e3e85517cfbd # v0.8.1

--- a/.github/workflows/org-terraform-fmt.yml
+++ b/.github/workflows/org-terraform-fmt.yml
@@ -24,6 +24,6 @@ on:
 
 jobs:
   terraform-docs:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-fmt.yml@v0.6.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-fmt.yml@3ce5211dee2e8758e2e992b13371e3e85517cfbd # v0.8.1
     with:
       terraform_version: "1.13.3"

--- a/.github/workflows/org-terraform-validate.yml
+++ b/.github/workflows/org-terraform-validate.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@v0.6.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@3ce5211dee2e8758e2e992b13371e3e85517cfbd # v0.8.1
     with:
       terraform_version: "1.13.3"
     secrets: inherit

--- a/.github/workflows/org-tree-readme.yml
+++ b/.github/workflows/org-tree-readme.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   readme-tree:
-    uses: Coalfire-CF/Actions/.github/workflows/org-tree-readme.yml@v0.5.1
+    uses: Coalfire-CF/Actions/.github/workflows/org-tree-readme.yml@3ce5211dee2e8758e2e992b13371e3e85517cfbd # v0.8.1
     with:
       commit_message: "chore: update README tree"
       exclude_pattern: ".git|node_modules|.github|dist|build"


### PR DESCRIPTION
## v0.8 unified wave (one PR per repo, least churn)

- **Re-pins every `Coalfire-CF/Actions` workflow ref to `3ce5211dee2e8758e2e992b13371e3e85517cfbd # v0.8.1`** — normalizes the v0.5.1/v0.6.0/v0.7.0/`main` fragmentation and converts bare tags to the ADR-0018 SHA+comment standard. The v0.8.1 delta is additive-only (gate-config feature is advisory-off; remainder is pin bumps).
- **Installs the dependabot auto-merge caller** (RFC-0010 practice 3): dependabot PRs are judged by OSV + OpenSSF Scorecard + AI changelog analysis; same-major greens auto-merge, majors/vulns/breaking block for human review. Terraform bumps always held. Proven: approve path ansible-aws#246 (run 28620299499), block path org-opa-policies#2.
- Supersedes this repo's open first-party dependabot bump PRs (they will be closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)