### PR TITLE
pilot: validate Actions#282 group-by via caller re-pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,11 @@ updates:
         exclude-patterns: ["Coalfire-CF/*"]
         update-types: ["minor", "patch"]
   - package-ecosystem: "terraform"
-    directory: "/"
+    directories:
+      - "/"
+      - "/modules/kv_certificates"
+      - "/modules/kv_certificates/example"
+      - "/modules/kv_key"
     schedule:
       interval: "daily"
       time: "09:04"
@@ -33,33 +37,12 @@ updates:
       include: "scope"
     labels:
       - "dep/terraform-module"
-  - package-ecosystem: "terraform"
-    directory: "/modules/kv_certificates"
-    schedule:
-      interval: "daily"
-      time: "09:04"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    labels:
-      - "dep/terraform-module"
-  - package-ecosystem: "terraform"
-    directory: "/modules/kv_certificates/example"
-    schedule:
-      interval: "daily"
-      time: "09:04"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    labels:
-      - "dep/terraform-module"
-  - package-ecosystem: "terraform"
-    directory: "/modules/kv_key"
-    schedule:
-      interval: "daily"
-      time: "09:04"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    labels:
-      - "dep/terraform-module"
+    groups:
+      terraform:
+        applies-to: version-updates
+        group-by: dependency-name
+        patterns: ["*"]
+      terraform-security:
+        applies-to: security-updates
+        group-by: dependency-name
+        patterns: ["*"]

--- a/.github/workflows/org-dependabot.yml
+++ b/.github/workflows/org-dependabot.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   refresh:
-    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot.yml@23aae589e2eb9c009fad0da45899db6ae59e8d02 # v0.16.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot.yml@7ca504a7006a39309fd269d7b2f1108073b8d4b5 # PILOT PR-282 fix/dependabot-group-by-directory REVERT after pilot
     with:
       head_branch: ${{ github.head_ref || github.ref_name }}  # PR head, or current branch if not a PR
       include_github_actions: "true"


### PR DESCRIPTION
## Faithful pilot for [Coalfire-CF/Actions#282](https://github.com/Coalfire-CF/Actions/pull/282)

### Why the first pilot (#157) merged as a no-op
key-vault's `org-dependabot.yml` caller runs on every PR, pinned to `Actions@v0.16.0` (pre-#282). When #157 pushed a hand-edited group-by `dependabot.yml`, the v0.16.0 generator ran on the PR and committed the **old** per-directory shape back over it. Net-zero merge. **Takeaway: the fix cannot be hand-applied; it only lands once a repo's Actions pin includes #282.**

### What this PR does
Re-pins the caller to the #282 branch SHA (`7ca504a7`). The generator that runs on THIS PR is now the #282 version, so it regenerates `.github/dependabot.yml` into the collapsed `directories:` + `group-by: dependency-name` shape and commits it onto this branch. This mirrors the real rollout, where a pin bump triggers regeneration.

### Acceptance checks after merge
1. The 4 open azurerm PRs (#151–#154) recreate as **one** consolidated PR across the 4 dirs.
2. Exactly one dependency per non-actions PR.
3. A real security advisory still opens a PR (check the Dependabot job log).

### Cleanup
The SHA pin is temporary — **revert to the release tag once #282 ships**. Flagged in the pin comment.